### PR TITLE
Open simulator on startup, quit if simulator is not open

### DIFF
--- a/Sources/Squirrel.xcodeproj/project.pbxproj
+++ b/Sources/Squirrel.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3CCEE255298A212E00783B28 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCEE254298A212E00783B28 /* ContentView.swift */; };
 		3CCEE257298A223700783B28 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCEE256298A223700783B28 /* main.swift */; };
 		3CCEE259298A28D900783B28 /* PointerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCEE258298A28D900783B28 /* PointerView.swift */; };
+		9363E71B298BC257008E1C40 /* AppDelegate+CheckSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9363E71A298BC257008E1C40 /* AppDelegate+CheckSimulator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		3CCEE254298A212E00783B28 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3CCEE256298A223700783B28 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		3CCEE258298A28D900783B28 /* PointerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointerView.swift; sourceTree = "<group>"; };
+		9363E71A298BC257008E1C40 /* AppDelegate+CheckSimulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CheckSimulator.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +72,7 @@
 			children = (
 				3CCEE256298A223700783B28 /* main.swift */,
 				3CCEE23F298A1EE500783B28 /* AppDelegate.swift */,
+				9363E71A298BC257008E1C40 /* AppDelegate+CheckSimulator.swift */,
 				3CCEE24E298A1F2F00783B28 /* ViewModel.swift */,
 				3C930E3C298B5309001843D4 /* ViewModel+Preferences.swift */,
 				3CCEE250298A1FFA00783B28 /* ViewModel+Scrolling.swift */,
@@ -154,6 +157,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9363E71B298BC257008E1C40 /* AppDelegate+CheckSimulator.swift in Sources */,
 				3CCEE259298A28D900783B28 /* PointerView.swift in Sources */,
 				3CCEE242298A1EE500783B28 /* Models.swift in Sources */,
 				3C930E3D298B5309001843D4 /* ViewModel+Preferences.swift in Sources */,
@@ -293,7 +297,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = WV6XDLHK3W;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -320,7 +324,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = WV6XDLHK3W;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSUIElement = YES;

--- a/Sources/Squirrel/AppDelegate+CheckSimulator.swift
+++ b/Sources/Squirrel/AppDelegate+CheckSimulator.swift
@@ -11,7 +11,13 @@ extension AppDelegate {
     func openSimulator() -> Bool {
         guard !isSimulatorOpen() && viewModel.launchSimulatorOnStartup else { return true }
         let url = URL(fileURLWithPath: viewModel.simulatorPath)
-        return NSWorkspace.shared.open(url)
+        if NSWorkspace.shared.open(url) {
+            return true
+        }
+        // if it failed to open the simulator, don't quit if simulator is closed
+        // as it will result in the app quitting right after startup
+        viewModel.quitIfSimulatorClosed = false
+        return false
     }
 
     func checkIfSimulatorIsOpen() {

--- a/Sources/Squirrel/AppDelegate+CheckSimulator.swift
+++ b/Sources/Squirrel/AppDelegate+CheckSimulator.swift
@@ -9,16 +9,13 @@ import Cocoa
 
 extension AppDelegate {
     func openSimulator() -> Bool {
+        guard !isSimulatorOpen() && Preferences.launchSimulatorOnStartup else { return true }
         let url = URL(fileURLWithPath: Preferences.simulatorPath)
         return NSWorkspace.shared.open(url)
     }
 
     func checkIfSimulatorIsOpen() {
-        let bundleUrl = URL(fileURLWithPath: Preferences.simulatorPath)
-        let applications = NSWorkspace.shared.runningApplications
-        if applications.first(where: { app in
-            app.bundleURL == bundleUrl
-        }) == nil {
+        if !isSimulatorOpen() && Preferences.quitIfSimulatorClosed {
             print("Simulator is closed!")
             NSApplication.shared.terminate(self)
         } else {
@@ -26,8 +23,16 @@ extension AppDelegate {
         }
 
         // check every ten seconds
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Preferences.simulatorCheckFrequency) { [weak self] in
             self?.checkIfSimulatorIsOpen()
+        }
+    }
+
+    func isSimulatorOpen() -> Bool {
+        let bundleUrl = URL(fileURLWithPath: Preferences.simulatorPath)
+        let applications = NSWorkspace.shared.runningApplications
+        return applications.contains { app in
+            app.bundleURL == bundleUrl
         }
     }
 }

--- a/Sources/Squirrel/AppDelegate+CheckSimulator.swift
+++ b/Sources/Squirrel/AppDelegate+CheckSimulator.swift
@@ -9,27 +9,24 @@ import Cocoa
 
 extension AppDelegate {
     func openSimulator() -> Bool {
-        guard !isSimulatorOpen() && Preferences.launchSimulatorOnStartup else { return true }
-        let url = URL(fileURLWithPath: Preferences.simulatorPath)
+        guard !isSimulatorOpen() && viewModel.launchSimulatorOnStartup else { return true }
+        let url = URL(fileURLWithPath: viewModel.simulatorPath)
         return NSWorkspace.shared.open(url)
     }
 
     func checkIfSimulatorIsOpen() {
-        if !isSimulatorOpen() && Preferences.quitIfSimulatorClosed {
-            print("Simulator is closed!")
+        if !isSimulatorOpen() && viewModel.quitIfSimulatorClosed {
             NSApplication.shared.terminate(self)
-        } else {
-            print("Simulator is open!")
         }
 
         // check every ten seconds
-        DispatchQueue.main.asyncAfter(deadline: .now() + Preferences.simulatorCheckFrequency) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + viewModel.simulatorCheckFrequency) { [weak self] in
             self?.checkIfSimulatorIsOpen()
         }
     }
 
     func isSimulatorOpen() -> Bool {
-        let bundleUrl = URL(fileURLWithPath: Preferences.simulatorPath)
+        let bundleUrl = URL(fileURLWithPath: viewModel.simulatorPath)
         let applications = NSWorkspace.shared.runningApplications
         return applications.contains { app in
             app.bundleURL == bundleUrl

--- a/Sources/Squirrel/AppDelegate+CheckSimulator.swift
+++ b/Sources/Squirrel/AppDelegate+CheckSimulator.swift
@@ -1,0 +1,33 @@
+//
+//  AppDelegate+CheckSimulator.swift
+//  Squirrel
+//
+//  Created by Kai Quan Tay on 2/2/23.
+//
+
+import Cocoa
+
+extension AppDelegate {
+    func openSimulator() -> Bool {
+        let url = URL(fileURLWithPath: Preferences.simulatorPath)
+        return NSWorkspace.shared.open(url)
+    }
+
+    func checkIfSimulatorIsOpen() {
+        let bundleUrl = URL(fileURLWithPath: Preferences.simulatorPath)
+        let applications = NSWorkspace.shared.runningApplications
+        if applications.first(where: { app in
+            app.bundleURL == bundleUrl
+        }) == nil {
+            print("Simulator is closed!")
+            NSApplication.shared.terminate(self)
+        } else {
+            print("Simulator is open!")
+        }
+
+        // check every ten seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+            self?.checkIfSimulatorIsOpen()
+        }
+    }
+}

--- a/Sources/Squirrel/AppDelegate.swift
+++ b/Sources/Squirrel/AppDelegate.swift
@@ -22,6 +22,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentViewController = NSHostingController(rootView: contentView)
         viewModel.popover = popover
         popover.delegate = viewModel
+
+        if !openSimulator() {
+            print("Error opening simulator!")
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+            self?.checkIfSimulatorIsOpen()
+        }
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/Sources/Squirrel/AppDelegate.swift
+++ b/Sources/Squirrel/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             print("Error opening simulator!")
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + Preferences.simulatorCheckFrequency) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + viewModel.simulatorCheckFrequency) { [weak self] in
             self?.checkIfSimulatorIsOpen()
         }
     }

--- a/Sources/Squirrel/AppDelegate.swift
+++ b/Sources/Squirrel/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             print("Error opening simulator!")
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Preferences.simulatorCheckFrequency) { [weak self] in
             self?.checkIfSimulatorIsOpen()
         }
     }

--- a/Sources/Squirrel/ContentView.swift
+++ b/Sources/Squirrel/ContentView.swift
@@ -71,6 +71,8 @@ struct ContentView: View {
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Size", value: $viewModel.pointerLength)
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Opacity", value: $viewModel.pointerOpacity)
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Scale", value: $viewModel.pointerScaleRatio)
+                MenuToggleRow(title: "Launch Simulator On Startup", isOn: $viewModel.launchSimulatorOnStartup)
+                MenuToggleRow(title: "Quit If Simulator Is Closed", isOn: $viewModel.quitIfSimulatorClosed)
             }
 
             VStack(alignment: .leading, spacing: 4.5) {
@@ -90,14 +92,20 @@ struct ContentView: View {
                 .buttonStyle(.plain)
 
                 if showingAdvanced {
-                    IntFieldRow(viewModel: viewModel, title: "Scroll Steps", value: $viewModel.numberOfScrollSteps)
-                    DoubleFieldRow(viewModel: viewModel, title: "Inactivity Timeout", value: $viewModel.scrollInactivityTimeout)
-                    DoubleFieldRow(viewModel: viewModel, title: "Scroll Interval", value: $viewModel.scrollInterval)
+                    Group {
+                        IntFieldRow(viewModel: viewModel, title: "Scroll Steps", value: $viewModel.numberOfScrollSteps)
+                        DoubleFieldRow(viewModel: viewModel, title: "Inactivity Timeout", value: $viewModel.scrollInactivityTimeout)
+                        DoubleFieldRow(viewModel: viewModel, title: "Scroll Interval", value: $viewModel.scrollInterval)
+                    }
 
-                    DoubleFieldRow(viewModel: viewModel, title: "Top Inset", value: $viewModel.deviceBezelInsetTop)
-                    DoubleFieldRow(viewModel: viewModel, title: "Left Inset", value: $viewModel.deviceBezelInsetLeft)
-                    DoubleFieldRow(viewModel: viewModel, title: "Right Inset", value: $viewModel.deviceBezelInsetRight)
-                    DoubleFieldRow(viewModel: viewModel, title: "Bottom Inset", value: $viewModel.deviceBezelInsetBottom)
+                    Group {
+                        DoubleFieldRow(viewModel: viewModel, title: "Top Inset", value: $viewModel.deviceBezelInsetTop)
+                        DoubleFieldRow(viewModel: viewModel, title: "Left Inset", value: $viewModel.deviceBezelInsetLeft)
+                        DoubleFieldRow(viewModel: viewModel, title: "Right Inset", value: $viewModel.deviceBezelInsetRight)
+                        DoubleFieldRow(viewModel: viewModel, title: "Bottom Inset", value: $viewModel.deviceBezelInsetBottom)
+                        PathFieldRow(viewModel: viewModel, title: "Simulator Location", value: $viewModel.simulatorPath)
+                        DoubleFieldRow(viewModel: viewModel, title: "Simulator Check Frequency", value: $viewModel.simulatorCheckFrequency)
+                    }
 
                     Button {
                         viewModel.resetPreferences()
@@ -177,6 +185,24 @@ struct IntFieldRow: View {
     }
 }
 
+struct PathFieldRow: View {
+    @ObservedObject var viewModel: ViewModel
+    var title: String
+    @Binding var value: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 8)
+
+            PathField(redrawPreferences: viewModel.redrawPreferences, value: $value)
+                .offset(y: -8)
+        }
+        .menuBackground()
+    }
+}
+
 struct DoubleField: View {
     var redrawPreferences: PassthroughSubject<Void, Never>
     @Binding var value: Double
@@ -225,6 +251,37 @@ struct IntField: View {
                 let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 if let int = Int(text) {
                     value = int
+                } else {
+                    self.text = "\(value)"
+                }
+                focused = false
+            }
+            .onAppear {
+                text = "\(value)"
+                focused = false
+            }
+            .onReceive(redrawPreferences) { _ in
+                text = "\(value)"
+                focused = false
+            }
+    }
+}
+
+struct PathField: View {
+    var redrawPreferences: PassthroughSubject<Void, Never>
+    @Binding var value: String
+    @State var text: String = ""
+    @FocusState var focused: Bool
+
+    var body: some View {
+        TextField("Integer", text: $text)
+            .multilineTextAlignment(.leading)
+//            .fixedSize(horizontal: true, vertical: false)
+            .focused($focused)
+            .focusable(false)
+            .onSubmit {
+                if FileManager.default.fileExists(atPath: text) {
+                    value = text
                 } else {
                     self.text = "\(value)"
                 }

--- a/Sources/Squirrel/ContentView.swift
+++ b/Sources/Squirrel/ContentView.swift
@@ -71,8 +71,16 @@ struct ContentView: View {
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Size", value: $viewModel.pointerLength)
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Opacity", value: $viewModel.pointerOpacity)
                 DoubleFieldRow(viewModel: viewModel, title: "Pointer Scale", value: $viewModel.pointerScaleRatio)
-                MenuToggleRow(title: "Launch Simulator On Startup", isOn: $viewModel.launchSimulatorOnStartup)
+                MenuToggleRow(title: "Launch Simulator On Startup", isOn: .init(get: {
+                    viewModel.launchSimulatorOnStartup
+                }, set: { newValue in
+                    viewModel.launchSimulatorOnStartup = newValue
+                    if newValue == false {
+                        viewModel.quitIfSimulatorClosed = false
+                    }
+                }))
                 MenuToggleRow(title: "Quit If Simulator Is Closed", isOn: $viewModel.quitIfSimulatorClosed)
+                    .disabled(viewModel.launchSimulatorOnStartup == false)
             }
 
             VStack(alignment: .leading, spacing: 4.5) {

--- a/Sources/Squirrel/ViewModel+Preferences.swift
+++ b/Sources/Squirrel/ViewModel+Preferences.swift
@@ -15,6 +15,8 @@ enum Preferences {
     static var pointerLength = CGFloat(20)
     static var pointerOpacity = CGFloat(0.95)
     static var pointerScaleRatio = CGFloat(1.4)
+    static var launchSimulatorOnStartup: Bool = true
+    static var simulatorPath: String = "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/"
     
     static var numberOfScrollSteps = 10
     static var scrollInactivityTimeout = CGFloat(1)

--- a/Sources/Squirrel/ViewModel+Preferences.swift
+++ b/Sources/Squirrel/ViewModel+Preferences.swift
@@ -16,7 +16,7 @@ enum Preferences {
     static var pointerOpacity = CGFloat(0.95)
     static var pointerScaleRatio = CGFloat(1.4)
     static var launchSimulatorOnStartup: Bool = true
-    static var simulatorPath: String = "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/"
+    static var quitIfSimulatorClosed: Bool = true
     
     static var numberOfScrollSteps = 10
     static var scrollInactivityTimeout = CGFloat(1)
@@ -25,6 +25,8 @@ enum Preferences {
     static var deviceBezelInsetLeft = CGFloat(20)
     static var deviceBezelInsetRight = CGFloat(20)
     static var deviceBezelInsetBottom = CGFloat(100)
+    static var simulatorPath: String = "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/"
+    static var simulatorCheckFrequency: TimeInterval = 10
 }
 
 extension ViewModel {
@@ -37,7 +39,9 @@ extension ViewModel {
         pointerLength = Preferences.pointerLength
         pointerOpacity = Preferences.pointerOpacity
         pointerScaleRatio = Preferences.pointerScaleRatio
-        
+        launchSimulatorOnStartup = Preferences.launchSimulatorOnStartup
+        quitIfSimulatorClosed = Preferences.quitIfSimulatorClosed
+
         numberOfScrollSteps = Preferences.numberOfScrollSteps
         scrollInactivityTimeout = Preferences.scrollInactivityTimeout
         scrollInterval = Preferences.scrollInterval
@@ -45,5 +49,7 @@ extension ViewModel {
         deviceBezelInsetLeft = Preferences.deviceBezelInsetLeft
         deviceBezelInsetRight = Preferences.deviceBezelInsetRight
         deviceBezelInsetBottom = Preferences.deviceBezelInsetBottom
+        simulatorPath = Preferences.simulatorPath
+        simulatorCheckFrequency = Preferences.simulatorCheckFrequency
     }
 }

--- a/Sources/Squirrel/ViewModel.swift
+++ b/Sources/Squirrel/ViewModel.swift
@@ -19,6 +19,8 @@ class ViewModel: NSObject, ObservableObject {
     @AppStorage("pointerLength") var pointerLength = Preferences.pointerLength
     @AppStorage("pointerOpacity") var pointerOpacity = Preferences.pointerOpacity
     @AppStorage("pointerScaleRatio") var pointerScaleRatio = Preferences.pointerScaleRatio
+    @AppStorage("launchSimulatorOnStartup") var launchSimulatorOnStartup = Preferences.launchSimulatorOnStartup
+    @AppStorage("quitIfSimulatorClosed") var quitIfSimulatorClosed = Preferences.quitIfSimulatorClosed
 
     // MARK: - Status Bar Properties
 
@@ -36,6 +38,8 @@ class ViewModel: NSObject, ObservableObject {
     @AppStorage("deviceBezelInsetLeft") var deviceBezelInsetLeft = Preferences.deviceBezelInsetLeft
     @AppStorage("deviceBezelInsetRight") var deviceBezelInsetRight = Preferences.deviceBezelInsetRight
     @AppStorage("deviceBezelInsetBottom") var deviceBezelInsetBottom = Preferences.deviceBezelInsetBottom
+    @AppStorage("simulatorPath") var simulatorPath = Preferences.simulatorPath
+    @AppStorage("simulatorCheckFrequency") var simulatorCheckFrequency = Preferences.simulatorCheckFrequency
     var pointerWindowLength: CGFloat {
         pointerLength * 5
     }


### PR DESCRIPTION
This PR implements a few settings:
- launchSimulatorOnStartup
	- Toggle for if the app launches the Simulator when it starts up. If this toggle is false, quitIfSimulatorClosed must also be false.
	- If the simulator is already open, it does not attempt to open it again
	- Defaults to true
- quitIfSimulatorClosed
	- Toggle for if the app quits if it detects that the Simulator is no longer open
	- Defaults to true
- simulatorPath (Advanced)
	- The path to the simulator
	- Defaults to "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/"
- simulatorCheckFrequency (Advanced)
	- How often the app checks if Simulator is open
	- Defaults to 10 seconds

These are all added to the ContentView and have persistence. 
Most of the functionality has been added to `AppDelegate+CheckSimulator`.