### PR TITLE
Fix accessibility instructions contrast on light backgrounds

### DIFF
--- a/Sources/Squirrel/ContentView.swift
+++ b/Sources/Squirrel/ContentView.swift
@@ -110,7 +110,7 @@ struct ContentView: View {
                         StepView(number: "3", title: "Accessibility")
                         StepView(number: "4", title: "Turn on for Squirrel")
                     }
-                    .foregroundColor(.blue)
+                    .contrast(0.6)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
                     .background(Color.blue.opacity(0.08))

--- a/Sources/Squirrel/Views.swift
+++ b/Sources/Squirrel/Views.swift
@@ -48,7 +48,7 @@ struct StepView: View {
                     Circle()
                         .fill(.blue)
                         .brightness(-0.2)
-                        .opacity(0.08)
+                        .opacity(0.4)
                 )
 
             Text(title)


### PR DESCRIPTION
Old versus new
<div style="display:flex;justify-content:center;">
<img width="272" alt="Screenshot 2023-02-03 at 11 19 10 PM" src="https://user-images.githubusercontent.com/16967687/216755410-4ed8495d-205c-4cd0-bfea-01d0c48638d8.png">

<img width="272" alt="Screenshot 2023-02-03 at 11 38 50 PM" src="https://user-images.githubusercontent.com/16967687/216755392-e3559806-8663-46ca-b049-d70620ac0331.png">
</div>
