### PR TITLE
Fix spacing on the screenshots table of the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,49 +24,9 @@ brew install hkamran80/things/squirrel
 
 ## Screenshots
 
-<table>
-
-<tr>
-<td>
-Main Menu
-</td>
-<td>
-Advanced Settings
-</td>
-</tr>
-
-<tr>
-</tr>
-  
-<tr>
-<td>
-<img src="Assets/MenuBar.png" alt="Menu Bar">
-</td>
-<td rowspan=5>
-<img src="Assets/MenuBar-Expanded.png" alt="Menu Bar Expanded">
-</td>
-</tr>
-
-<tr>
-</tr>
-  
-<tr>
-<td>
-Dark Mode
-</td>
-</tr>
-  
-<tr>
-</tr>
-
-  
-<tr>
-<td>
-<img src="Assets/MenuBar-Dark.png" alt="Menu Bar Dark Mode">
-</td>
-</tr>
- 
-</table>
+Main Menu | Advanced Settings
+--|--
+Light Mode<br><img src="Assets/MenuBar.png" alt="Menu Bar"><br>Dark Mode<br><img src="Assets/MenuBar-Dark.png" alt="Menu Bar Dark Mode"> | <img src="Assets/MenuBar-Expanded.png" alt="Menu Bar Expanded">
 
 <table>
 <tr>


### PR DESCRIPTION
Before | After
--|--
<img width="715" alt="Screenshot 2023-02-04 at 18 44 05" src="https://user-images.githubusercontent.com/16542463/216784297-3b0a091f-55c5-438a-9934-1d21b771e8c1.png"> | <img width="723" alt="Screenshot 2023-02-04 at 18 44 15" src="https://user-images.githubusercontent.com/16542463/216784303-6b3950fe-d943-4e37-b3b0-048a410862ec.png">
